### PR TITLE
Add 404 error page

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -21,7 +21,7 @@ config :store, StoreWeb.Endpoint,
   http: [ip: {127, 0, 0, 1}, port: 4000],
   check_origin: false,
   code_reloader: true,
-  debug_errors: true,
+  debug_errors: false,
   secret_key_base: "zMHIYq32Z65TLjzAQSui4hnZ8zIeADYspbFpd0oRMwsVEV1gbOTkJPfPdEOV/sq6",
   watchers: [
     # Start the esbuild watcher by calling Esbuild.install_and_run(:default, args)

--- a/lib/store_web/templates/error/404_page.html.eex
+++ b/lib/store_web/templates/error/404_page.html.eex
@@ -1,0 +1,20 @@
+<div class="grid h-screen place-items-center">
+    <div class="px-4">
+        <div class="font-bold pb-2 text-center text-xl">
+            <div class="text-3xl">
+                <p>404</p>
+            </div>
+            <p>Page Not Found</p>
+        </div>
+        <div class="text-center pt-4">
+            <p>We can't seem to find the page you're looking for.<br> The link you followed may be broken, or the page may have been removed.</p>
+            <div class="pt-8">
+                <a href="/">
+                    <button type="button" class="w-full inline-flex items-center bg-white py-4 text-black hover:text-white border-2 border-gray-200 hover:border-[#f47c58] hover:border-2 shadow-sm hover:bg-[#f47c58] font-bold">
+                        <span class="w-full text-center"> Return home </span>
+                    </button>
+                </a>
+            </div>
+        </div>
+    <div>
+</div>

--- a/lib/store_web/views/error_view.ex
+++ b/lib/store_web/views/error_view.ex
@@ -7,6 +7,13 @@ defmodule StoreWeb.ErrorView do
   #   "Internal Server Error"
   # end
 
+  def render("404.html", assigns) do
+    render(StoreWeb.ErrorView, "404_page.html",
+      layout: {StoreWeb.LayoutView, "root.html"},
+      conn: assigns.conn
+    )
+  end
+
   # By default, Phoenix returns the status message from
   # the template name. For example, "404.html" becomes
   # "Not Found".


### PR DESCRIPTION
Adds a custom 404 error page. 

_NOTE_: To see the error page in a development environment, set `debug_errors: false` on `dev.exs`

_PREVIEW:_
![image](https://user-images.githubusercontent.com/30907944/203159778-f7e32cbc-d3d5-475b-81e2-21c5280e81c8.png)
