### PR TITLE
Add confirmation modals to backoffice buttons

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -68,7 +68,6 @@
     margin: 15vh auto;
     padding: 20px;
     border: 1px solid #888;
-    width: 80%;
   }
   
   .phx-modal-close {

--- a/lib/store_web/live/backoffice/order_live/show.ex
+++ b/lib/store_web/live/backoffice/order_live/show.ex
@@ -8,7 +8,6 @@ defmodule StoreWeb.Backoffice.OrderLive.Show do
   alias Store.Accounts
   alias StoreWeb.Emails.OrdersEmail
   alias Store.Mailer
-  alias JS
   @impl true
   def mount(%{"id" => id}, _session, socket) do
     {:ok, assign(socket, order: Inventory.get_order!(id), confirm_event: "")}

--- a/lib/store_web/live/backoffice/order_live/show.ex
+++ b/lib/store_web/live/backoffice/order_live/show.ex
@@ -1,16 +1,17 @@
 defmodule StoreWeb.Backoffice.OrderLive.Show do
   use StoreWeb, :live_view
-
   import Store.Inventory
+  alias Phoenix.LiveView.JS
   alias Store.Repo
   alias Store.Inventory
   alias Store.Uploaders
   alias Store.Accounts
   alias StoreWeb.Emails.OrdersEmail
   alias Store.Mailer
+  alias JS
   @impl true
   def mount(%{"id" => id}, _session, socket) do
-    {:ok, assign(socket, order: Inventory.get_order!(id))}
+    {:ok, assign(socket, order: Inventory.get_order!(id), confirm_event: "")}
   end
 
   @impl true
@@ -19,6 +20,7 @@ defmodule StoreWeb.Backoffice.OrderLive.Show do
      socket
      |> assign(:current_page, :orders)
      |> assign(:page_title, page_title(socket.assigns.live_action))
+     |> assign(:confirm_event, "")
      |> assign(:order, Inventory.get_order!(id) |> Repo.preload(:products))}
   end
 
@@ -35,6 +37,7 @@ defmodule StoreWeb.Backoffice.OrderLive.Show do
 
     {:noreply,
      socket
+     |> assign(:confirm_event, "")
      |> put_flash(:info, "Order status updated successfly")
      |> push_redirect(to: socket.assigns.return_to)}
   end
@@ -52,6 +55,7 @@ defmodule StoreWeb.Backoffice.OrderLive.Show do
 
     {:noreply,
      socket
+     |> assign(:confirm_event, "")
      |> put_flash(:info, "Order status updated successfly")
      |> push_redirect(to: socket.assigns.return_to)}
   end
@@ -67,8 +71,15 @@ defmodule StoreWeb.Backoffice.OrderLive.Show do
 
     {:noreply,
      socket
+     |> assign(:confirm_event, "")
      |> put_flash(:info, "Order status updated successfly")
      |> push_redirect(to: socket.assigns.return_to)}
+  end
+
+  def handle_event("confirm", %{"confirm_event" => confirm_event}, socket) do
+    {:noreply,
+     socket
+     |> assign(:confirm_event, confirm_event)}
   end
 
   defp user_email(id) do

--- a/lib/store_web/live/backoffice/order_live/show.html.heex
+++ b/lib/store_web/live/backoffice/order_live/show.html.heex
@@ -34,7 +34,10 @@
               <%= if @order.status != :draft && @order.status != :delivered do %>
                 <%= if @order.status != :ready do %>
                   <button
-                    phx-click="ready"
+                    phx-click={
+                      JS.push("confirm", value: %{confirm_event: "ready"}) |> show_modal()
+                    }
+                    phx-value="ready"
                     class="flex w-32 items-center justify-center bg-black px-2.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#f47c58]"
                   >
                     <span>Ready</span>
@@ -42,14 +45,18 @@
                 <% end %>
                 <%= if @order.status != :paid do %>
                   <button
-                    phx-click="paid"
+                    phx-click={
+                      JS.push("confirm", value: %{confirm_event: "paid"}) |> show_modal()
+                    }
                     class="flex w-32 items-center justify-center bg-black px-2.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#f47c58]"
                   >
                     <span>Paid</span>
                   </button>
                 <% end %>
                 <button
-                  phx-click="delivered"
+                  phx-click={
+                    JS.push("confirm", value: %{confirm_event: "delivered"}) |> show_modal()
+                  }
                   class="flex w-32 items-center justify-center bg-black px-2.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-[#f47c58]"
                 >
                   <span>Delivered</span>
@@ -126,3 +133,87 @@
     </div>
   </section>
 </main>
+<.modal hide_close_button={true}>
+  <%= if @confirm_event != "" do %>
+    <button
+      id="close"
+      type="button"
+      phx-click={JS.push("confirm", value: %{confirm_event: ""}) |> hide_modal()}
+      class="top-3 right-2.5 float-right ml-auto inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm hover:bg-gray-200 hover:text-gray-900"
+      data-modal-hide="popup-modal"
+    >
+      <svg
+        aria-hidden="true"
+        class="h-5 w-5"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+          clip-rule="evenodd"
+        >
+        </path>
+      </svg>
+      <span class="sr-only">Close modal</span>
+    </button>
+    <div class="p-6 text-center">
+      <svg
+        aria-hidden="true"
+        class="mx-auto mb-4 h-14 w-14"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+        >
+        </path>
+      </svg>
+      <h3 class="mb-5 text-lg font-normal">
+        Are you sure you want to change this orders state to <%= @confirm_event %>?
+      </h3>
+      <button
+        phx-click={
+          if @confirm_event != "" do
+            JS.push(@confirm_event) |> hide_modal()
+          end
+        }
+        class="bg-secondary mr-2 inline-flex items-center rounded-lg px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-orange-600 focus:outline-none focus:ring-4 focus:ring-red-300"
+      >
+        Yes, I'm sure
+      </button>
+      <button
+        phx-click={JS.push("confirm", value: %{confirm_event: ""}) |> hide_modal()}
+        type="button"
+        class="rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium hover:bg-gray-100 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-200"
+      >
+        No, cancel
+      </button>
+    </div>
+  <% else %>
+    <div class="p-6 text-center">
+      <svg
+        aria-hidden="true"
+        class="fill-primary mr-2 inline h-8 w-8 animate-spin text-gray-200"
+        viewBox="0 0 100 101"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+          fill="currentColor"
+        />
+        <path
+          d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+          fill="currentFill"
+        />
+      </svg>
+    </div>
+  <% end %>
+</.modal>

--- a/lib/store_web/live/backoffice/product_live/form_component.html.heex
+++ b/lib/store_web/live/backoffice/product_live/form_component.html.heex
@@ -16,7 +16,7 @@
             <div
               phx-click={show_modal()}
               type="button"
-              class="bg-secondary cursor-pointer flex w-full items-center justify-center rounded-md border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg:primary xl:w-full"
+              class="bg-secondary flex w-full cursor-pointer items-center justify-center rounded-md border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg:primary xl:w-full"
             >
               Save
             </div>
@@ -261,12 +261,36 @@
     </div>
     <.modal>
       <div class="p-6 text-center">
-        <svg aria-hidden="true" class="mx-auto mb-4 w-14 h-14" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+        <svg
+          aria-hidden="true"
+          class="mx-auto mb-4 h-14 w-14"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          >
+          </path>
+        </svg>
         <h3 class="mb-5 text-lg font-normal">Are you sure you want to save these changes?</h3>
-        <button type="submit" class="text-white bg-secondary hover:bg-orange-600 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center mr-2">
-            Yes, I'm sure
+        <button
+          type="submit"
+          class="bg-secondary mr-2 inline-flex items-center rounded-lg px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-orange-600 focus:outline-none focus:ring-4 focus:ring-red-300"
+        >
+          Yes, I'm sure
         </button>
-        <button phx-click={hide_modal()} type="button" class="bg-white hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200 rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 focus:z-10">No, cancel</button>
+        <button
+          phx-click={hide_modal()}
+          type="button"
+          class="rounded-lg border border-gray-200 bg-white px-5 py-2.5 text-sm font-medium hover:bg-gray-100 focus:z-10 focus:outline-none focus:ring-4 focus:ring-gray-200"
+        >
+          No, cancel
+        </button>
       </div>
     </.modal>
   </.form>

--- a/lib/store_web/live/backoffice/product_live/form_component.html.heex
+++ b/lib/store_web/live/backoffice/product_live/form_component.html.heex
@@ -12,14 +12,15 @@
         <div class="flex h-10 items-center justify-between">
           <h1 class="flex-1 text-lg font-medium">Store</h1>
           <!-- Action buttons -->
-          <%= submit do %>
+          <div>
             <div
+              phx-click={show_modal()}
               type="button"
-              class="bg-secondary inline-flex w-14 items-center justify-center rounded-md border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg:primary xl:w-full"
+              class="bg-secondary cursor-pointer flex w-full items-center justify-center rounded-md border-transparent px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg:primary xl:w-full"
             >
               Save
             </div>
-          <% end %>
+          </div>
         </div>
       </div>
 
@@ -258,5 +259,15 @@
         </div>
       </div>
     </div>
+    <.modal>
+      <div class="p-6 text-center">
+        <svg aria-hidden="true" class="mx-auto mb-4 w-14 h-14" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>
+        <h3 class="mb-5 text-lg font-normal">Are you sure you want to save these changes?</h3>
+        <button type="submit" class="text-white bg-secondary hover:bg-orange-600 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm inline-flex items-center px-5 py-2.5 text-center mr-2">
+            Yes, I'm sure
+        </button>
+        <button phx-click={hide_modal()} type="button" class="bg-white hover:bg-gray-100 focus:ring-4 focus:outline-none focus:ring-gray-200 rounded-lg border border-gray-200 text-sm font-medium px-5 py-2.5 focus:z-10">No, cancel</button>
+      </div>
+    </.modal>
   </.form>
 </div>

--- a/lib/store_web/live/backoffice/product_live/form_component.html.heex
+++ b/lib/store_web/live/backoffice/product_live/form_component.html.heex
@@ -259,7 +259,7 @@
         </div>
       </div>
     </div>
-    <.modal>
+    <.modal hide_close_button={false}>
       <div class="p-6 text-center">
         <svg
           aria-hidden="true"

--- a/lib/store_web/live/live_helpers.ex
+++ b/lib/store_web/live/live_helpers.ex
@@ -27,10 +27,10 @@ defmodule StoreWeb.LiveHelpers do
     assigns = assign_new(assigns, :return_to, fn -> nil end)
 
     ~H"""
-    <div id="modal" class="phx-modal fade-in" phx-remove={hide_modal()}>
+    <div id="modal" class="phx-modal fade-in hidden" phx-remove={hide_modal()}>
       <div
         id="modal-content"
-        class="phx-modal-content fade-in-scale"
+        class="phx-modal-content fade-in-scale rounded-xl max-w-md"
         phx-click-away={JS.dispatch("click", to: "#close")}
         phx-window-keydown={JS.dispatch("click", to: "#close")}
         phx-key="escape"
@@ -43,7 +43,10 @@ defmodule StoreWeb.LiveHelpers do
             phx_click: hide_modal()
           ) %>
         <% else %>
-          <a id="close" href="#" class="phx-modal-close" phx-click={hide_modal()}>✖</a>
+          <button id="close" type="button" phx-click={hide_modal()} class="float-right top-3 right-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center" data-modal-hide="popup-modal">
+            <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+            <span class="sr-only">Close modal</span>
+          </button>
         <% end %>
 
         <%= render_slot(@inner_block) %>
@@ -52,9 +55,15 @@ defmodule StoreWeb.LiveHelpers do
     """
   end
 
-  defp hide_modal(js \\ %JS{}) do
+  def hide_modal(js \\ %JS{}) do
     js
     |> JS.hide(to: "#modal", transition: "fade-out")
     |> JS.hide(to: "#modal-content", transition: "fade-out-scale")
+  end
+
+  def show_modal(js \\ %JS{}) do
+    js
+    |> JS.show(to: "#modal", transition: "fade-in")
+    |> JS.show(to: "#modal-content", transition: "fade-in-scale")
   end
 end

--- a/lib/store_web/live/live_helpers.ex
+++ b/lib/store_web/live/live_helpers.ex
@@ -28,7 +28,7 @@ defmodule StoreWeb.LiveHelpers do
     assigns = assign_new(assigns, :hide_close_button, fn -> nil end)
 
     ~H"""
-    <div id="modal" class="phx-modal fade-in hidden" phx-remove={hide_modal()}>
+    <div id="modal" class="phx-modal fade-in hidden px-2" phx-remove={hide_modal()}>
       <div
         id="modal-content"
         class="phx-modal-content fade-in-scale max-w-md rounded-xl"

--- a/lib/store_web/live/live_helpers.ex
+++ b/lib/store_web/live/live_helpers.ex
@@ -25,12 +25,13 @@ defmodule StoreWeb.LiveHelpers do
   """
   def modal(assigns) do
     assigns = assign_new(assigns, :return_to, fn -> nil end)
+    assigns = assign_new(assigns, :hide_close_button, fn -> nil end)
 
     ~H"""
     <div id="modal" class="phx-modal fade-in hidden" phx-remove={hide_modal()}>
       <div
         id="modal-content"
-        class="phx-modal-content fade-in-scale rounded-xl max-w-md"
+        class="phx-modal-content fade-in-scale max-w-md rounded-xl"
         phx-click-away={JS.dispatch("click", to: "#close")}
         phx-window-keydown={JS.dispatch("click", to: "#close")}
         phx-key="escape"
@@ -43,10 +44,31 @@ defmodule StoreWeb.LiveHelpers do
             phx_click: hide_modal()
           ) %>
         <% else %>
-          <button id="close" type="button" phx-click={hide_modal()} class="float-right top-3 right-2.5 bg-transparent hover:bg-gray-200 hover:text-gray-900 rounded-lg text-sm p-1.5 ml-auto inline-flex items-center" data-modal-hide="popup-modal">
-            <svg aria-hidden="true" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
-            <span class="sr-only">Close modal</span>
-          </button>
+          <%= if not @hide_close_button do %>
+            <button
+              id="close"
+              type="button"
+              phx-click={hide_modal()}
+              class="top-3 right-2.5 float-right ml-auto inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm hover:bg-gray-200 hover:text-gray-900"
+              data-modal-hide="popup-modal"
+            >
+              <svg
+                aria-hidden="true"
+                class="h-5 w-5"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                  clip-rule="evenodd"
+                >
+                </path>
+              </svg>
+              <span class="sr-only">Close modal</span>
+            </button>
+          <% end %>
         <% end %>
 
         <%= render_slot(@inner_block) %>
@@ -59,11 +81,13 @@ defmodule StoreWeb.LiveHelpers do
     js
     |> JS.hide(to: "#modal", transition: "fade-out")
     |> JS.hide(to: "#modal-content", transition: "fade-out-scale")
+    |> JS.remove_class("overflow-hidden", to: "#root")
   end
 
   def show_modal(js \\ %JS{}) do
     js
     |> JS.show(to: "#modal", transition: "fade-in")
     |> JS.show(to: "#modal-content", transition: "fade-in-scale")
+    |> JS.add_class("overflow-hidden", to: "#root")
   end
 end

--- a/lib/store_web/templates/layout/root.html.heex
+++ b/lib/store_web/templates/layout/root.html.heex
@@ -15,7 +15,7 @@
     >
     </script>
   </head>
-  <body>
+  <body id="root">
     <%= @inner_content %>
   </body>
 </html>


### PR DESCRIPTION
This PR improves the modal helper in `live_helpers.ex`, and uses it on the product edit and order edit pages.

_PREVIEW:_

![image](https://user-images.githubusercontent.com/30907944/225003828-73db5573-82d2-4438-8a03-6c7120e54e38.png)
![image](https://user-images.githubusercontent.com/30907944/225004077-29eb5926-e590-4792-b9a7-80056b471554.png)
